### PR TITLE
Remove duplicate 'Veggie Burger' item from restaurant 'Urban Burger'

### DIFF
--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -74,12 +74,6 @@ menuItem7 = MenuItem(name="Grilled Cheese Sandwich", description="On texas toast
 session.add(menuItem7)
 session.commit()
 
-menuItem8 = MenuItem(name="Veggie Burger", description="Made with freshest of ingredients and home grown spices",
-                     price="$5.99", course="Entree", restaurant=restaurant1)
-
-session.add(menuItem8)
-session.commit()
-
 
 # Menu for Super Stir Fry
 restaurant2 = Restaurant(name="Super Stir Fry")


### PR DESCRIPTION
Removing the duplicate "Veggie Burger" item from the "Urban Burger" menu makes this code more consistent with the lecture. It is confusing to find a duplicate record when following along with the lecturer. In the demonstration, the lecturer finds only one "Veggie Burger" item per restaurant ID.