### PR TITLE
Remove duplicate 'Veggie Burger' item from 'Urban Burger' restaurant …

### DIFF
--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -25,12 +25,6 @@ restaurant1 = Restaurant(name="Urban Burger")
 session.add(restaurant1)
 session.commit()
 
-menuItem2 = MenuItem(name="Veggie Burger", description="Juicy grilled veggie patty with tomato mayo and lettuce",
-                     price="$7.50", course="Entree", restaurant=restaurant1)
-
-session.add(menuItem2)
-session.commit()
-
 
 menuItem1 = MenuItem(name="French Fries", description="with garlic and parmesan",
                      price="$2.99", course="Appetizer", restaurant=restaurant1)


### PR DESCRIPTION
The current lotsofmenus.py code is inconsistent with the lecture video:

1. There is a duplicate 'Veggie Burger' item in the menu for the 'Urban Burger' restaurant. This duplicate record does not exist in the lecture.

2. Due to the duplicate record, the ID of the correct 'Veggie Burger' item does not match the lecture video.

This pull request resolves both issues.