### PR TITLE
Fix encoding error while wfile.write in first web server of Lesson-1

### DIFF
--- a/Lesson-2/first-web-server/webserver.py
+++ b/Lesson-2/first-web-server/webserver.py
@@ -10,7 +10,7 @@ class WebServerHandler(BaseHTTPRequestHandler):
             self.end_headers()
             message = ""
             message += "<html><body>Hello!</body></html>"
-            self.wfile.write(message.encode()encoding='utf_8')
+            self.wfile.write(message.encode(encoding='utf_8'))
             print message
             return
         else:

--- a/Lesson-2/first-web-server/webserver.py
+++ b/Lesson-2/first-web-server/webserver.py
@@ -10,7 +10,7 @@ class WebServerHandler(BaseHTTPRequestHandler):
             self.end_headers()
             message = ""
             message += "<html><body>Hello!</body></html>"
-            self.wfile.write(message)
+            self.wfile.write(message.encode()encoding='utf_8')
             print message
             return
         else:


### PR DESCRIPTION
Exception happened during processing of request from ('127.0.0.1', 52760)
Traceback (most recent call last):
File "/usr/lib/python3.5/socketserver.py", line 318, in handlerequest_noblock
self.process_request(request, client_address)
File "/usr/lib/python3.5/socketserver.py", line 344, in process_request
self.finish_request(request, client_address)
File "/usr/lib/python3.5/socketserver.py", line 357, in finish_request
self.RequestHandlerClass(request, client_address, self)
File "/usr/lib/python3.5/socketserver.py", line 684, in init
self.handle()
File "/usr/lib/python3.5/http/server.py", line 415, in handle
self.handle_one_request()
File "/usr/lib/python3.5/http/server.py", line 403, in handle_one_request
method()
File "t.py", line 13, in do_GET
self.wfile.write(message)
File "/usr/lib/python3.5/socket.py", line 593, in write
return self._sock.send(b)
TypeError: a bytes-like object is required, not 'str'

To get rid of the error, on the latest python version, change the
following line:
self.wfile.write(message)
to:
self.wfile.write(message.encode(encoding='utf_8'))