### PR TITLE
Clean Auntie Ann's restaurant name string

### DIFF
--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -284,7 +284,7 @@ session.commit()
 
 
 # Menu for Auntie Ann's
-restaurant1 = Restaurant(name="Auntie Ann\'s Diner' ")
+restaurant1 = Restaurant(name="Auntie Ann\'s Diner")
 
 session.add(restaurant1)
 session.commit()


### PR DESCRIPTION
As written, the name string returned for Auntie Ann's Diner is u"Auntie Ann's Diner' ".

This entry specifically is mentioned in the Udacity lecture videos.  The unexpected extra single quote and space in this string make it less intuitive to write comparison checks to ensure that the desired result was returned.

Hence, delete the trailing single quote and space.