### PR TITLE
Set Urban's veggie burger ID to 8

### DIFF
--- a/Lesson_1/lotsofmenus.py
+++ b/Lesson_1/lotsofmenus.py
@@ -25,12 +25,6 @@ restaurant1 = Restaurant(name="Urban Burger")
 session.add(restaurant1)
 session.commit()
 
-menuItem2 = MenuItem(name="Veggie Burger", description="Juicy grilled veggie patty with tomato mayo and lettuce",
-                     price="$7.50", course="Entree", restaurant=restaurant1)
-
-session.add(menuItem2)
-session.commit()
-
 
 menuItem1 = MenuItem(name="French Fries", description="with garlic and parmesan",
                      price="$2.99", course="Appetizer", restaurant=restaurant1)


### PR DESCRIPTION
As written, this Python script gives Urban two veggie burgers.  As the ID's are assigned auto-increment, the IDs of Urban's two(?) veggie burgers are 1 and 9 respectively.

This does not match Udacity's lecture video, which proceeds under the assumption that Urban's (single) veggie burger has the id of 8.  This causes unnecessary confusion and detracts from the lecture.