### PR TITLE
Use consistent routing variables

### DIFF
--- a/Lesson-3/12_Edit-Menu-Form/project.py
+++ b/Lesson-3/12_Edit-Menu-Form/project.py
@@ -59,10 +59,10 @@ def newMenuItem(restaurant_id):
         return render_template('newmenuitem.html', restaurant_id=restaurant_id)
 
 
-@app.route('/restaurants/<int:restaurant_id>/<int:MenuID>/edit',
+@app.route('/restaurants/<int:restaurant_id>/<int:menu_id>/edit',
            methods=['GET', 'POST'])
-def editMenuItem(restaurant_id, MenuID):
-    editedItem = session.query(MenuItem).filter_by(id=MenuID).one()
+def editMenuItem(restaurant_id, menu_id):
+    editedItem = session.query(MenuItem).filter_by(id=menu_id).one()
     if request.method == 'POST':
         if request.form['name']:
             editedItem.name = request.form['name']
@@ -73,7 +73,7 @@ def editMenuItem(restaurant_id, MenuID):
         # USE THE RENDER_TEMPLATE FUNCTION BELOW TO SEE THE VARIABLES YOU
         # SHOULD USE IN YOUR EDITMENUITEM TEMPLATE
         return render_template(
-            'editmenuitem.html', restaurant_id=restaurant_id, MenuID=MenuID, item=editedItem)
+            'editmenuitem.html', restaurant_id=restaurant_id, menu_id=menu_id, item=editedItem)
 
 
 @app.route('/restaurant/<int:restaurant_id>/<int:menu_id>/delete/')


### PR DESCRIPTION
As distributed, project.py for this quiz renders the editmenuitem.html template with the chosen parameter names "restaurant_id", "MenuID", and "item". As such, editmenuitem.html is constrained to using those variable names to access the respective objects, and throws an error when trying to obtain "menu_id" in line 3 (indeed, there is no "menu_id").

An intuitive solution would be to edit line 3 of `editmenuitem.html` so that it looks for "MenuID" (as discussed in https://github.com/lobrown/Full-Stack-Foundations/pull/62).

However, menu.html also expects the variable to be named "menu_id".

Stylistically, rather than changing all instances of the previously-used "menu_id" to the apparently novel "MenuID", simply change project.py to consistently use "menu_id" internally and when passing parameters to templates (e.g. `editmenuitem.html`).